### PR TITLE
Adding cmdclass argument to setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
     setup_requires=['numpy'],
     packages=['stickydesign'],
     ext_modules=[stickyext],
+    cmdclass={'build_ext':build_ext},
     package_data={'stickydesign': ['params/dnastackingbig.csv']},
     author="Constantine Glen Evans",
     author_email="cevans@evans.foundation",


### PR DESCRIPTION
There is a bug in the setup.py file, where the new build_ext class is not passed to the setup() call. 